### PR TITLE
Fix for error occurs when running SPEC CPU benchmark

### DIFF
--- a/llheap.cc
+++ b/llheap.cc
@@ -586,7 +586,7 @@ static void heapManagerDtor() {
 	shadow_heap = heapManager;
 	#endif // ! OWNERSHIP
 	heapManager = nullptr;
-
+	heapManagerBootFlag = false;
 	spin_release( &heapMaster.mgrLock );
 } // heapManagerDtor
 
@@ -942,8 +942,7 @@ static void * manager_extend( size_t size ) {
 
 #define PROLOG( counter, ... ) \
 	BOOT_HEAP_MANAGER; \
-	if ( UNLIKELY( size == 0 ) ||						/* 0 BYTE ALLOCATION RETURNS NULL POINTER */ \
-		UNLIKELY( size > ULONG_MAX - sizeof(Heap::Storage) ) ) { /* error check */ \
+	if ( UNLIKELY( size > ULONG_MAX - sizeof(Heap::Storage) ) ) { /* error check */ \
 		STAT_0_CNT( counter ); \
 		__VA_ARGS__; \
 		return nullptr; \


### PR DESCRIPTION
There are two errors shows up when I ran SPEC CPU with llheap as the allocator.
1. When requesting a size 0 pointer, it is returning a nullptr. However, runtime/classic-flang does not expect a nullptr return.
2. When libc calls __call_tls_dtor, the heapManagerDtor is being called in ~ThreadManager. However, the HeapManagerBootFlag is not being changed accordingly. Thus, when the program call doMalloc in some way, there will be a segmentation fault.
